### PR TITLE
fix: invalid function pointer conversion compile error

### DIFF
--- a/src/evaluation/source/util/EvalLog.cpp
+++ b/src/evaluation/source/util/EvalLog.cpp
@@ -30,7 +30,7 @@ namespace eval {
  * @param {int} size
  * @return {*}
  */
-void SignalHandle(const char* data, int size)
+void SignalHandle(const char* data, size_t size)
 {
   std::ofstream fs("glog_dump.log", std::ios::app);
   std::string str = std::string(data, size);

--- a/src/operation/iPL/source/module/logger/Log.cc
+++ b/src/operation/iPL/source/module/logger/Log.cc
@@ -40,7 +40,7 @@ namespace ipl {
  * @param {int} size
  * @return {*}
  */
-void SignalHandle(const char* data, int size)
+void SignalHandle(const char* data, size_t size)
 {
   std::ofstream fs("glog_dump.log", std::ios::app);
   std::string str = std::string(data, size);

--- a/src/utility/log/Log.cc
+++ b/src/utility/log/Log.cc
@@ -39,7 +39,7 @@ namespace ieda {
  * @param data
  * @param size
  */
-void SignalHandle(const char* data, int size)
+void SignalHandle(const char* data, size_t size)
 {
   std::ofstream fs("glog_dump.log", std::ios::app);
   std::string str = std::string(data, size);


### PR DESCRIPTION
## Build Environment
**OS**: 
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.1 LTS
Release:	24.04
Codename:	noble

**GCC Version**:
Default gcc-10 (i.e., gcc version 10.5.0 (Ubuntu 10.5.0-4ubuntu2))
 
## Error Message
Mismatch of function pointer cause compile error:
```shell
/home/movic/iEDA/src/utility/log/Log.cc: In static member function ‘static void ieda::Log::init(char**, std::string)’:
/home/movic/iEDA/src/utility/log/Log.cc:79:32: error: invalid conversion from ‘void (*)(const char*, int)’ to ‘void (*)(const char*, size_t)’ {aka ‘void (*)(const char*, long unsigned int)’} [-fpermissive]
   79 |   google::InstallFailureWriter(&SignalHandle);
      |                                ^~~~~~~~~~~~~
      |                                |
      |                                void (*)(const char*, int)
In file included from /home/movic/iEDA/src/utility/log/Log.hh:27,
                 from /home/movic/iEDA/src/utility/log/Log.cc:25:
/usr/include/glog/logging.h:1992:12: note:   initializing argument 1 of ‘void google::InstallFailureWriter(void (*)(const char*, size_t))’
 1992 |     void (*writer)(const char* data, size_t size));
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

## Solution
Fixed by replace `int` with `size_t`.