### PR TITLE
Resolve unique_ptr destructor access error in `NotificationUtility` class

### DIFF
--- a/src/utility/notification/NotificationUtility.h
+++ b/src/utility/notification/NotificationUtility.h
@@ -169,9 +169,10 @@ public:
      */
     bool waitForPendingNotifications(int timeout_ms = 0);
 
+    ~NotificationUtility();
+
 private:
     NotificationUtility() = default;
-    ~NotificationUtility();
 
     // Disable copy constructor and assignment operator
     NotificationUtility(const NotificationUtility&) = delete;


### PR DESCRIPTION
## Background

The `NotificationUtility` class declared its destructor as private, but was being managed by std::unique_ptr with the default deleter. This caused a compilation error because std::default_delete requires public access to the destructor.

Full compilation log in [GitHub Action](https://github.com/oscc-ip/artifact/actions/runs/16039273494/job/45257557592#step:6:1680)

## Error Message

```
[1174/1248] Building CXX object src/utility/notification/CMakeFiles/notification.dir/NotificationUtility.cpp.o
FAILED: [code=1] src/utility/notification/CMakeFiles/notification.dir/NotificationUtility.cpp.o 
/usr/local/bin/c++ -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DGLOG_USE_GLOG_EXPORT -Dnotification_EXPORTS -I/home/runner/work/artifact/artifact/src/utility/stdBase -I/home/runner/work/artifact/artifact/src/utility/stdBase/include -I/home/runner/work/artifact/artifact/src/utility -I/home/runner/work/artifact/artifact/src/operation/iSTA -I/home/runner/work/artifact/artifact/src/operation/iSTA/source -I/home/runner/work/artifact/artifact/src/operation/iSTA/source/module -I/home/runner/work/artifact/artifact/src/operation/iSTA/source/module/include -I/home/runner/work/artifact/artifact/src/operation/iPA -I/home/runner/work/artifact/artifact/src/operation/iPA/source -I/home/runner/work/artifact/artifact/src/operation/iPA/source/module -I/home/runner/work/artifact/artifact/src/operation/iPA/source/module/include -I/home/runner/work/artifact/artifact/src/database/manager/parser/rust-common -I/home/runner/work/artifact/artifact/src/utility/stdBase/graph -I/home/runner/work/artifact/artifact/src/utility/log -I/home/runner/work/artifact/artifact/src/utility/string -I/home/runner/work/artifact/artifact/src/utility/tcl -I/home/runner/work/artifact/artifact/src/utility/notification -isystem /home/runner/work/artifact/artifact/src/third_party -isystem /home/runner/work/artifact/artifact/src/third_party/json -isystem /usr/include/eigen3 -isystem /home/runner/work/artifact/artifact/src/third_party/yaml-cpp/include -Wno-error -fpermissive -fPIC -fopenmp -Wno-error -fpermissive -fPIC -O3 -Wall -Werror=return-type -std=gnu++2a -fPIC -MD -MT src/utility/notification/CMakeFiles/notification.dir/NotificationUtility.cpp.o -MF src/utility/notification/CMakeFiles/notification.dir/NotificationUtility.cpp.o.d -o src/utility/notification/CMakeFiles/notification.dir/NotificationUtility.cpp.o -c /home/runner/work/artifact/artifact/src/utility/notification/NotificationUtility.cpp
In file included from /usr/include/c++/10/memory:83,
                 from /home/runner/work/artifact/artifact/src/utility/notification/NotificationUtility.h:21,
                 from /home/runner/work/artifact/artifact/src/utility/notification/NotificationUtility.cpp:17:
/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = ieda::NotificationUtility]’:
/usr/include/c++/10/bits/unique_ptr.h:361:17:   required from ‘std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = ieda::NotificationUtility; _Dp = std::default_delete<ieda::NotificationUtility>]’
/home/runner/work/artifact/artifact/src/utility/notification/NotificationUtility.cpp:33:71:   required from here
/usr/include/c++/10/bits/unique_ptr.h:85:2: error: ‘ieda::NotificationUtility::~NotificationUtility()’ is private within this context
   85 |  delete __ptr;
      |  ^~~~~~~~~~~~
/home/runner/work/artifact/artifact/src/utility/notification/NotificationUtility.cpp:59:1: note: declared private here
   59 | NotificationUtility::~NotificationUtility() {
      | ^~~~~~~~~~~~~~~~~~~
```